### PR TITLE
Links all point back to original repo, causing confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ This project was initially developed to help with the creator's system-wide prac
 
 ## Features
 
+
 - **Multi-layout support**: The following layouts are currently natively supported.
   <details>
   <summary>Layouts</summary>


### PR DESCRIPTION
(No issues on repo so raising here)

Hey @Coobaha — all the links in the README.md redirect back to the original project. As a result, some folks (e.g., me :)) who come here from places like [TailorKey](https://sites.google.com/view/tailorkey/moergo/go60/get-it-now-go60?authuser=0) are seeing issues (like looking for the referenced DMG, which has a link that goes back to the original project's release page, which has no DMG), but are then following links (like "Ask a Question") in the readme back to the original repo and trying to raise the issue there.

It might make sense to enable issues and/or make it more clear in the README that the links aren't for this project.